### PR TITLE
favicon image buffers

### DIFF
--- a/server.js
+++ b/server.js
@@ -153,7 +153,9 @@ app.get('/:from(\\w+)/:to(\\w+)?/:image(*.png)', function (request, response) {
     return response.sendStatus(403);
   }
   var image = iconGenerator.getIcon(request.params.from, request.params.to, request.params.image);
-  response.sendFile(image, { root: './' });
+
+  response.type('png');
+  response.send(image);
 });
 
 app.get('/favicon-32x32.png', function (request, response) {
@@ -190,7 +192,9 @@ app.get('*/manifest.json', function (request, response) {
 
 app.get('/:image(*.png)', function (request, response) {
   var image = iconGenerator.getIcon('TRN', 'TXT', request.params.image);
-  response.sendFile(image, { root: './' });
+
+  response.type('png');
+  response.send(image)
 });
 
 app.get('*/browserconfig.xml', function (request, response) {

--- a/src/iconGenerator.js
+++ b/src/iconGenerator.js
@@ -75,8 +75,7 @@ function generateIcon(text, format, size, fileName) {
     image.draw(images(letterImagePath), x, y);
     x += 32 + characterWidths[text[i]];
   }
-  image.resize(size).save(fileName);
-  return fileName;
+  return image.resize(size).encode('png');
 }
 
 function getCharacterWidth(letter) {


### PR DESCRIPTION
This changes the way that dynamic favicons are served.

Rather than writing the file to disk and serving from there a file buffer is sent directly to the client.

It should be a bit more efficient/nicer for the server and avoids a bunch of assets being dumped in the project.