### PR TITLE
Optipng

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "extend": "3.0.0",
     "images": "3.0.0",
     "mongoose": "4.5.9",
+    "optipng": "^1.1.0",
     "pug": "^2.0.0-beta5",
     "request": "2.79.0",
     "soap": "0.11.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "pug": "^2.0.0-beta5",
     "request": "2.79.0",
     "soap": "0.11.4",
+    "streamifier": "^0.1.1",
     "ua-parser-js": "0.7.10"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -153,7 +153,9 @@ app.get('/:from(\\w+)/:to(\\w+)?/:image(*.png)', function (request, response) {
     return response.sendStatus(403);
   }
   var image = iconGenerator.getIcon(request.params.from, request.params.to, request.params.image);
-  response.sendFile(image, { root: './' });
+
+  response.type('png');
+  response.send(image);
 });
 
 app.get('/favicon-32x32.png', function (request, response) {
@@ -190,7 +192,9 @@ app.get('*/manifest.json', function (request, response) {
 
 app.get('/:image(*.png)', function (request, response) {
   var image = iconGenerator.getIcon('TRN', 'TXT', request.params.image);
-  response.sendFile(image, { root: './' });
+
+  response.type('png');
+  response.send(image)
 });
 
 app.get('*/browserconfig.xml', function (request, response) {

--- a/server.js
+++ b/server.js
@@ -155,7 +155,7 @@ app.get('/:from(\\w+)/:to(\\w+)?/:image(*.png)', function (request, response) {
   var image = iconGenerator.getIcon(request.params.from, request.params.to, request.params.image);
 
   response.type('png');
-  response.send(image);
+  image.pipe(response);
 });
 
 app.get('/favicon-32x32.png', function (request, response) {
@@ -194,7 +194,7 @@ app.get('/:image(*.png)', function (request, response) {
   var image = iconGenerator.getIcon('TRN', 'TXT', request.params.image);
 
   response.type('png');
-  response.send(image)
+  image.pipe(response);
 });
 
 app.get('*/browserconfig.xml', function (request, response) {

--- a/src/iconGenerator.js
+++ b/src/iconGenerator.js
@@ -1,6 +1,7 @@
 var crypto = require('crypto');
 var fs = require('fs');
 var images = require('images');
+var OptiPng = require('optipng');
 var streamifier = require('streamifier');
 
 var iconPath = 'resources/iconGenerator/';
@@ -79,7 +80,7 @@ function generateIcon(text, format, size, fileName) {
 
   var buffer = image.resize(size).encode('png');
   var stream = streamifier.createReadStream(buffer);
-  return stream
+  return stream.pipe(new OptiPng())
 }
 
 function getCharacterWidth(letter) {

--- a/src/iconGenerator.js
+++ b/src/iconGenerator.js
@@ -1,6 +1,7 @@
 var crypto = require('crypto');
 var fs = require('fs');
 var images = require('images');
+var streamifier = require('streamifier');
 
 var iconPath = 'resources/iconGenerator/';
 
@@ -75,7 +76,10 @@ function generateIcon(text, format, size, fileName) {
     image.draw(images(letterImagePath), x, y);
     x += 32 + characterWidths[text[i]];
   }
-  return image.resize(size).encode('png');
+
+  var buffer = image.resize(size).encode('png');
+  var stream = streamifier.createReadStream(buffer);
+  return stream
 }
 
 function getCharacterWidth(letter) {

--- a/src/iconGenerator.js
+++ b/src/iconGenerator.js
@@ -75,8 +75,7 @@ function generateIcon(text, format, size, fileName) {
     image.draw(images(letterImagePath), x, y);
     x += 32 + characterWidths[text[i]];
   }
-  image.resize(size).save(fileName);
-  return fileName;
+  return image.resize(size).encode('png');
 }
 
 function getCharacterWidth(letter) {


### PR DESCRIPTION
(note - this is branched from #41)

I'm not sure if this is very necessary - but it runs the favicon images through [optipng](https://www.npmjs.com/package/optipng) which would reduce the size.

pros:
* ~%30 filesize reduction

cons:
* slower response times
* potentially awkward for deploy/dev - adds a couple of dependencies with os-specific binaries
* it's already a pretty tiny file - doesn't make much difference overall

When I tested locally:

before: 8.1k ~100ms
after: 5.7k ~200ms

… so it's pretty negligible (especially because the files are downloaded in the background).  Though if you're wanting to hyper-optimise network, then maybe it'll help.

![optipng](https://user-images.githubusercontent.com/51385/28634970-d0347054-7230-11e7-8e75-4683aba884a0.png)
